### PR TITLE
feat: add move cues function with testing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@
 export * from './parseSnapshot'
 export * from './createTimestamps'
 export * from './fastDeepEqual'
+export * from './moveCues'

--- a/src/moveCues.ts
+++ b/src/moveCues.ts
@@ -28,46 +28,58 @@ export async function moveCues (
   const newCueOrder: RundownCueOrderItem[] = []
   let currentIndex = 0
 
+  // If the destination is the very beginning of the rundown, insert the selected items first
   if (mainIndex === 0) newCueOrder.push(...selectedItems)
 
   for (const item of cueOrder) {
     currentIndex++
 
+    // If the item has no children (it's a single cue)
     if (!item.children) {
+      // Add the item to the new order if it hasn't been selected for moving
       if (!selectedCueIds.has(item.id)) newCueOrder.push(item)
-      if (currentIndex === mainIndex && subIndex === undefined) {
-        newCueOrder.push(...selectedItems)
-      }
     } else {
+      // The item has children (it's a group)
       const children = []
       let childIndex = 0
 
+      // If the destination is the beginning of this group, insert selected items
       if (currentIndex === mainIndex && subIndex === 0) {
         children.push(...selectedItems)
       }
 
+      // Iterate through each child of the group
       for (const child of item.children) {
         childIndex++
+
+        // Add the child to the group if it hasn't been selected for moving
         if (!selectedCueIds.has(child.id)) children.push(child)
+
+        // If the current and child indices match the destination, insert selected items
         if (currentIndex === mainIndex && childIndex === subIndex) {
           children.push(...selectedItems)
         }
       }
 
+      // If the subIndex is greater than the last child's index, insert selected items at the end
       if (mainIndex === currentIndex && subIndex > childIndex) {
         children.push(...selectedItems)
       }
 
+      // Add the group to the new order if it hasn't been selected for moving
       if (!selectedCueIds.has(item.id)) {
         newCueOrder.push({ id: item.id, children })
       }
+    }
 
-      if (currentIndex === mainIndex && subIndex === undefined) {
-        newCueOrder.push(...selectedItems)
-      }
+    // If the current index matches the mainIndex and there's no subIndex,
+    // insert the selected items
+    if (currentIndex === mainIndex && subIndex === undefined) {
+      newCueOrder.push(...selectedItems)
     }
   }
 
+  // If the destination index is beyond the last item, append the selected items at the end
   if (mainIndex > currentIndex) newCueOrder.push(...selectedItems)
 
   return newCueOrder

--- a/src/moveCues.ts
+++ b/src/moveCues.ts
@@ -1,5 +1,28 @@
 import { Rundown, RundownCueOrderItem } from '@rundown-studio/types'
 
+/**
+ * Moves selected cues to a new position within the rundown's cue order.
+ * This function reorders the cues based on a specified destination index and
+ * validates that group headers cannot be moved into another group.
+ *
+ * @async
+ * @function
+ * @param {RundownCueOrderItem[]} cueOrder - The original array representing the current order of cues.
+ * @param {Array<Rundown['id']>} selectedCues - An array of IDs for the cues that should be moved.
+ * @param {string} destination - A string representing the target position in the form "mainIndex.subIndex".
+ *                                - `mainIndex` refers to the position of the cue or group in the main order.
+ *                                - `subIndex` (optional) refers to the position within a group's children.
+ *
+ * @throws {Error} Throws an error if a group header is attempted to be moved inside another group.
+ *
+ * @return {Promise<RundownCueOrderItem[]>} - A promise that resolves to the new order of cues (`newCueOrder`)
+ *                                            after the selected cues have been moved.
+ *
+ * @description
+ * - Parses the destination to determine the main and sub-level positions.
+ * - Removes the selected cues from their original positions and inserts them at the destination.
+ * - Ensures that groups are not improperly nested within other groups.
+ */
 export async function moveCues (
   cueOrder: RundownCueOrderItem[],
   selectedCues: Array<Rundown['id']>,

--- a/src/moveCues.ts
+++ b/src/moveCues.ts
@@ -1,0 +1,82 @@
+import { Rundown, RundownCueOrderItem } from '@rundown-studio/types'
+
+/**
+ * Moves selected cues to a new position within the rundown's cues order.
+ * This function reorders the cues based on a given destination string and validates
+ * that group headers cannot be nested within other groups.
+ *
+ * @async
+ * @function
+ * @param {RundownCueOrderItem[]} cueOrder - Original cue order, representing actual position of each cue.
+ * @param {Array<string>} selectedCues - Array of IDs for the cues to be moved.
+ * @param {string} destination - A string representing the target index position in the form "\d+\.?\d*"
+ *                               (e.g., "4" for a main level position or "4.2" for a position within a group).
+ *
+ * @throws {Error} Will throw an error if a group header is moved into another group, as nested groups are not allowed.
+ *
+ * @return {Promise<RundownCueOrderItem[]>} - A promise that resolves to the new order of cues (`newCuesOrder`)
+ *                                             after the selected cues have been moved.
+ *
+ * @description
+ * This function:
+ * - Retrieves the rundown cues order from the service.
+ * - Identifies and collects the selected cues and their current positions within the rundown.
+ * - Validates the destination for group header movements to prevent nested groups.
+ * - Removes selected cues from their original positions.
+ * - Inserts the selected cues into the specified position based on `destination`.
+ *
+ * @example
+ * // Moves selected cues to position after index 4.2
+ * await moveCues('rundown123', ['cueId1', 'cueId2'], '4.2')
+ */
+export async function moveCues (
+  cueOrder: RundownCueOrderItem[],
+  selectedCues: Array<Rundown['id']>,
+  destination: string,
+): Promise<RundownCueOrderItem[]> {
+  const newCuesOrder = [...cueOrder]
+  const parsedInput = destination.split('.').map(Number) // e.g., '4.2' becomes [4, 2]
+  const mainIndex = parsedInput[0] - 1 // Adjust to 0-based index
+  const subIndex = parsedInput[1] !== undefined ? parsedInput[1] - 1 : null
+
+  const selectedCueIds = new Set(selectedCues)
+  const selectedItems = []
+
+  // Flatten cuesOrder for easier manipulation
+  for (const [i, cue] of newCuesOrder.entries()) {
+    if (selectedCueIds.has(cue.id)) {
+      selectedItems.push({ item: cue, index: i })
+      continue
+    }
+    if (cue.children) {
+      const childrenToRemove: Array<number> = []
+      for (const [j, child] of cue.children.entries()) {
+        if (selectedCueIds.has(child.id)) {
+          selectedItems.push({ item: child, groupIndex: i, childIndex: j })
+          childrenToRemove.push(j)
+        }
+      }
+      cue.children = cue.children.filter((_, idx) => !childrenToRemove.includes(idx))
+    }
+  }
+
+  if (selectedItems.some(({ item }) => item.children) && subIndex !== null) {
+    throw new Error('Cannot move a group header inside another group')
+  }
+
+  for (const { index, groupIndex, childIndex } of selectedItems.reverse()) {
+    if (index !== undefined) {
+      newCuesOrder.splice(index, 1)
+    } else if (groupIndex !== undefined && childIndex !== undefined) {
+      newCuesOrder[groupIndex].children?.splice(childIndex, 1)
+    }
+  }
+
+  if (subIndex !== null) {
+    newCuesOrder[mainIndex].children?.splice(subIndex + 1, 0, ...selectedItems.map(({ item }) => item))
+  } else {
+    newCuesOrder.splice(mainIndex + 1, 0, ...selectedItems.map(({ item }) => item))
+  }
+
+  return newCuesOrder
+}

--- a/src/moveCues.ts
+++ b/src/moveCues.ts
@@ -28,7 +28,8 @@ export async function moveCues (
   selectedCues: Array<Rundown['id']>,
   destination: string,
 ): Promise<RundownCueOrderItem[]> {
-  const selectedItems = selectCueOrderItems(cueOrder, selectedCues)
+  const selectedCueIds = new Set(selectedCues)
+  const selectedItems = selectCueOrderItems(cueOrder, selectedCueIds)
   const parsedInput = destination.split('.').map(Number)
   const mainIndex = parsedInput[0]
   const subIndex = parsedInput[1]
@@ -48,7 +49,7 @@ export async function moveCues (
   for (const cueOrderItem of cueOrder) {
     idx++
     if (!cueOrderItem.children) {
-      if (!selectedCues.includes(cueOrderItem.id)) {
+      if (!selectedCueIds.has(cueOrderItem.id)) {
         newCueOrder.push(cueOrderItem)
       }
       if (idx == mainIndex && subIndex == undefined) newCueOrder.push(...selectedItems)
@@ -58,7 +59,7 @@ export async function moveCues (
       if (idx == mainIndex && subIndex == 0) children.push(...selectedItems)
       for (const cueOrderItemChildren of cueOrderItem.children) {
         childIdx++
-        if (!selectedCues.includes(cueOrderItemChildren.id)) {
+        if (!selectedCueIds.has(cueOrderItemChildren.id)) {
           children.push(cueOrderItemChildren)
         }
         if (idx == mainIndex && childIdx == subIndex) children.push(...selectedItems)
@@ -66,7 +67,7 @@ export async function moveCues (
       if (mainIndex == idx && subIndex > childIdx) {
         children.push(...selectedItems)
       }
-      if (!selectedCues.includes(cueOrderItem.id)) {
+      if (!selectedCueIds.has(cueOrderItem.id)) {
         newCueOrder.push({ id: cueOrderItem.id, children })
       }
       if (idx == mainIndex && subIndex == undefined) newCueOrder.push(...selectedItems)
@@ -85,20 +86,20 @@ export async function moveCues (
  *
  * @function
  * @param {RundownCueOrderItem[]} cueOrder - The original array of cue order items.
- * @param {Array<Rundown['id']>} selectedCues - An array of IDs representing the cues to be selected.
+ * @param {Set<Rundown['id']>} selectedCues - An array of IDs representing the cues to be selected.
  * @return {{ items: RundownCueOrderItem[], hasGroups: boolean }} - An object containing:
  *   - `items`: The selected cue items.
  *   - `hasGroups`: A boolean indicating whether any of the selected items are groups.
  */
 function selectCueOrderItems (
   cueOrder: RundownCueOrderItem[],
-  selectedCues: Array<Rundown['id']>,
+  selectedCues: Set<Rundown['id']>,
 ): RundownCueOrderItem[] {
   const items: RundownCueOrderItem[] = []
 
   for (const cueOrderItem of cueOrder) {
     // If the current item is in the selectedCues list, add it to the items array
-    if (selectedCues.includes(cueOrderItem.id)) {
+    if (selectedCues.has(cueOrderItem.id)) {
       items.push(cueOrderItem)
       continue
     }
@@ -108,7 +109,7 @@ function selectCueOrderItems (
 
     for (const child of cueOrderItem.children) {
       // If the child is in the selectedCues list, add it to the items array
-      if (selectedCues.includes(child.id)) {
+      if (selectedCues.has(child.id)) {
         // If the current item has children, mark that there are groups
         items.push(child)
       }

--- a/src/moveCues.ts
+++ b/src/moveCues.ts
@@ -2,26 +2,14 @@ import { Rundown, RundownCueOrderItem } from '@rundown-studio/types'
 
 /**
  * Moves selected cues to a new position within the rundown's cue order.
- * This function reorders the cues based on a specified destination index and
- * validates that group headers cannot be moved into another group.
  *
  * @async
  * @function
- * @param {RundownCueOrderItem[]} cueOrder - The original array representing the current order of cues.
- * @param {Array<Rundown['id']>} selectedCues - An array of IDs for the cues that should be moved.
- * @param {string} destination - A string representing the target position in the form "mainIndex.subIndex".
- *                                - `mainIndex` refers to the position of the cue or group in the main order.
- *                                - `subIndex` (optional) refers to the position within a group's children.
- *
- * @throws {Error} Throws an error if a group header is attempted to be moved inside another group.
- *
- * @return {Promise<RundownCueOrderItem[]>} - A promise that resolves to the new order of cues (`newCueOrder`)
- *                                            after the selected cues have been moved.
- *
- * @description
- * - Parses the destination to determine the main and sub-level positions.
- * - Removes the selected cues from their original positions and inserts them at the destination.
- * - Ensures that groups are not improperly nested within other groups.
+ * @param {RundownCueOrderItem[]} cueOrder - The original array of cue order items.
+ * @param {Array<Rundown['id']>} selectedCues - IDs of the cues to move.
+ * @param {string} destination - Target position formatted as "mainIndex.subIndex".
+ * @throws {Error} If a group header is attempted to be moved inside another group.
+ * @return {Promise<RundownCueOrderItem[]>} - The reordered cue array.
  */
 export async function moveCues (
   cueOrder: RundownCueOrderItem[],
@@ -29,92 +17,77 @@ export async function moveCues (
   destination: string,
 ): Promise<RundownCueOrderItem[]> {
   const selectedCueIds = new Set(selectedCues)
-  const selectedItems = selectCueOrderItems(cueOrder, selectedCueIds)
-  const parsedInput = destination.split('.').map(Number)
-  const mainIndex = parsedInput[0]
-  const subIndex = parsedInput[1]
+  const selectedItems = selectCueItems(cueOrder, selectedCueIds)
+  const [mainIndex, subIndex] = destination.split('.').map(Number)
 
-  // Error handling: prevent adding a group into another group
-  if (selectedItems.find((i) => i.children) && subIndex) {
+  // Prevent moving a group header into another group
+  if (selectedItems.some((item) => item.children) && subIndex !== undefined) {
     throw new Error('Cannot move a group header inside another group')
   }
 
   const newCueOrder: RundownCueOrderItem[] = []
-  let idx = 0
+  let currentIndex = 0
 
-  if (mainIndex == 0) {
-    newCueOrder.push(...selectedItems)
-  }
+  if (mainIndex === 0) newCueOrder.push(...selectedItems)
 
-  for (const cueOrderItem of cueOrder) {
-    idx++
-    if (!cueOrderItem.children) {
-      if (!selectedCueIds.has(cueOrderItem.id)) {
-        newCueOrder.push(cueOrderItem)
+  for (const item of cueOrder) {
+    currentIndex++
+
+    if (!item.children) {
+      if (!selectedCueIds.has(item.id)) newCueOrder.push(item)
+      if (currentIndex === mainIndex && subIndex === undefined) {
+        newCueOrder.push(...selectedItems)
       }
-      if (idx == mainIndex && subIndex == undefined) newCueOrder.push(...selectedItems)
     } else {
       const children = []
-      let childIdx = 0
-      if (idx == mainIndex && subIndex == 0) children.push(...selectedItems)
-      for (const cueOrderItemChildren of cueOrderItem.children) {
-        childIdx++
-        if (!selectedCueIds.has(cueOrderItemChildren.id)) {
-          children.push(cueOrderItemChildren)
-        }
-        if (idx == mainIndex && childIdx == subIndex) children.push(...selectedItems)
-      }
-      if (mainIndex == idx && subIndex > childIdx) {
+      let childIndex = 0
+
+      if (currentIndex === mainIndex && subIndex === 0) {
         children.push(...selectedItems)
       }
-      if (!selectedCueIds.has(cueOrderItem.id)) {
-        newCueOrder.push({ id: cueOrderItem.id, children })
+
+      for (const child of item.children) {
+        childIndex++
+        if (!selectedCueIds.has(child.id)) children.push(child)
+        if (currentIndex === mainIndex && childIndex === subIndex) {
+          children.push(...selectedItems)
+        }
       }
-      if (idx == mainIndex && subIndex == undefined) newCueOrder.push(...selectedItems)
+
+      if (mainIndex === currentIndex && subIndex > childIndex) {
+        children.push(...selectedItems)
+      }
+
+      if (!selectedCueIds.has(item.id)) {
+        newCueOrder.push({ id: item.id, children })
+      }
+
+      if (currentIndex === mainIndex && subIndex === undefined) {
+        newCueOrder.push(...selectedItems)
+      }
     }
   }
 
-  if (mainIndex > idx) {
-    newCueOrder.push(...selectedItems)
-  }
+  if (mainIndex > currentIndex) newCueOrder.push(...selectedItems)
 
   return newCueOrder
 }
 
 /**
- * Selects and extracts cue order items based on their IDs, and determines if any of the selected items are groups.
+ * Selects cue order items based on their IDs.
  *
  * @function
  * @param {RundownCueOrderItem[]} cueOrder - The original array of cue order items.
- * @param {Set<Rundown['id']>} selectedCues - An array of IDs representing the cues to be selected.
- * @return {{ items: RundownCueOrderItem[], hasGroups: boolean }} - An object containing:
- *   - `items`: The selected cue items.
- *   - `hasGroups`: A boolean indicating whether any of the selected items are groups.
+ * @param {Set<Rundown['id']>} selectedCues - IDs of the cues to select.
+ * @return {RundownCueOrderItem[]} - The selected cue items.
  */
-function selectCueOrderItems (
+function selectCueItems (
   cueOrder: RundownCueOrderItem[],
   selectedCues: Set<Rundown['id']>,
 ): RundownCueOrderItem[] {
-  const items: RundownCueOrderItem[] = []
-
-  for (const cueOrderItem of cueOrder) {
-    // If the current item is in the selectedCues list, add it to the items array
-    if (selectedCues.has(cueOrderItem.id)) {
-      items.push(cueOrderItem)
-      continue
-    }
-
-    // If the current item has no children, skip to the next item
-    if (!cueOrderItem.children) continue
-
-    for (const child of cueOrderItem.children) {
-      // If the child is in the selectedCues list, add it to the items array
-      if (selectedCues.has(child.id)) {
-        // If the current item has children, mark that there are groups
-        items.push(child)
-      }
-    }
-  }
-
-  return items
+  return cueOrder.flatMap((item) => {
+    if (selectedCues.has(item.id)) return [item]
+    if (!item.children) return []
+    return item.children.filter((child) => selectedCues.has(child.id))
+  })
 }

--- a/tests/moveCues.test.js
+++ b/tests/moveCues.test.js
@@ -1,0 +1,228 @@
+import { expect } from 'chai'
+import { moveCues } from '../dist/esm/index.js'
+
+/**
+ * npm run test -- tests/moveCues.test.js
+ */
+
+const cueOrder = [
+  { id: 'cue1' }, // 1
+  { id: 'cue2' }, // 2
+  {
+    id: 'group1', // 3
+    children: [
+      { id: 'cue3' }, // 3.1
+      { id: 'cue4' }, // 3.2
+    ],
+  },
+  { id: 'cue5' }, // 4
+  {
+    id: 'group2', // 5
+    children: [
+      { id: 'cue6' }, // 5.1
+      { id: 'cue7' }, // 5.2
+    ],
+  },
+  { id: 'cue8' }, // 6
+]
+
+describe('moveCues', () => {
+  it('moves selected cue into a group position', async () => {
+    const selectedCues = ['cue5']
+    const destination = '3.2'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+          { id: 'cue5' },
+        ],
+      },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+    ])
+  })
+
+  it('moves selected cue into the first position', async () => {
+    const selectedCues = ['cue5']
+    const destination = '0'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue5' },
+      { id: 'cue1' },
+      { id: 'cue2' },
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+        ],
+      },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+    ])
+  })
+
+  it('moves selected cue into the last position', async () => {
+    const selectedCues = ['cue5']
+    const destination = '6'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+        ],
+      },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+      { id: 'cue5' },
+    ])
+  })
+
+  it('moves selected cues into the last position', async () => {
+    const selectedCues = ['cue1', 'cue2']
+    const destination = '6'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+        ],
+      },
+      { id: 'cue5' },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+      { id: 'cue1' },
+      { id: 'cue2' },
+    ])
+  })
+
+  it('moves selected cues after group', async () => {
+    const selectedCues = ['cue1', 'cue2']
+    const destination = '3'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+        ],
+      },
+      { id: 'cue1' },
+      { id: 'cue2' },
+      { id: 'cue5' },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+    ])
+  })
+
+  it('moves group to the end', async () => {
+    const selectedCues = ['group1']
+    const destination = '6'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      { id: 'cue5' },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+        ],
+      },
+    ])
+  })
+
+  it('moves group after group', async () => {
+    const selectedCues = ['group1']
+    const destination = '5'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      { id: 'cue5' },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+        ],
+      },
+      { id: 'cue8' },
+    ])
+  })
+
+  it.only('moves group inside group', async () => {
+    const selectedCues = ['group1']
+    const destination = '3.1'
+    try {
+      await moveCues(cueOrder, selectedCues, destination)
+    } catch (error) {
+      expect(error.message).to.equal('Cannot move a group header inside another group')
+    }
+  })
+})

--- a/tests/moveCues.test.js
+++ b/tests/moveCues.test.js
@@ -6,83 +6,83 @@ import { moveCues } from '../dist/esm/index.js'
  */
 
 const cueOrder = [
-  { id: 'cue1' }, // 1
-  { id: 'cue2' }, // 2
+  { id: 'cue1' },
+  { id: 'cue2' },
   {
-    id: 'group1', // 3
+    id: 'group3',
     children: [
-      { id: 'cue3' }, // 3.1
-      { id: 'cue4' }, // 3.2
+      { id: 'cue3.1' },
+      { id: 'cue3.2' },
     ],
   },
-  { id: 'cue5' }, // 4
+  { id: 'cue4' },
   {
-    id: 'group2', // 5
+    id: 'group5',
     children: [
-      { id: 'cue6' }, // 5.1
-      { id: 'cue7' }, // 5.2
+      { id: 'cue5.1' },
+      { id: 'cue5.2' },
     ],
   },
-  { id: 'cue8' }, // 6
+  { id: 'cue6' },
 ]
 
 describe('moveCues', () => {
   it('moves selected cue into the first position', async () => {
-    const selectedCues = ['cue5']
+    const selectedCues = ['cue4']
     const destination = '0'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
     expect(newCueOrder).to.deep.equal([
-      { id: 'cue5' },
+      { id: 'cue4' },
       { id: 'cue1' },
       { id: 'cue2' },
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
-          { id: 'cue4' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
         ],
       },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
+      { id: 'cue6' },
     ])
   })
 
   it('moves selected cue into a middle position', async () => {
-    const selectedCues = ['cue5']
+    const selectedCues = ['cue4']
     const destination = '2'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
     expect(newCueOrder).to.deep.equal([
       { id: 'cue1' },
       { id: 'cue2' },
-      { id: 'cue5' },
+      { id: 'cue4' },
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
-          { id: 'cue4' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
         ],
       },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
+      { id: 'cue6' },
     ])
   })
 
   it('moves selected cue into the last position', async () => {
-    const selectedCues = ['cue5']
+    const selectedCues = ['cue4']
     const destination = '6'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
@@ -90,26 +90,26 @@ describe('moveCues', () => {
       { id: 'cue1' },
       { id: 'cue2' },
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
-          { id: 'cue4' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
         ],
       },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
-      { id: 'cue5' },
+      { id: 'cue6' },
+      { id: 'cue4' },
     ])
   })
 
   it('moves selected cue into the last position (using higher number)', async () => {
-    const selectedCues = ['cue5']
+    const selectedCues = ['cue4']
     const destination = '100'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
@@ -117,26 +117,26 @@ describe('moveCues', () => {
       { id: 'cue1' },
       { id: 'cue2' },
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
-          { id: 'cue4' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
         ],
       },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
-      { id: 'cue5' },
+      { id: 'cue6' },
+      { id: 'cue4' },
     ])
   })
 
   it('moves selected cue to a begining of group', async () => {
-    const selectedCues = ['cue5']
+    const selectedCues = ['cue4']
     const destination = '3.0'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
@@ -144,26 +144,26 @@ describe('moveCues', () => {
       { id: 'cue1' },
       { id: 'cue2' },
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue5' },
-          { id: 'cue3' },
           { id: 'cue4' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
         ],
       },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
+      { id: 'cue6' },
     ])
   })
 
   it('moves selected cue the middle of group', async () => {
-    const selectedCues = ['cue5']
+    const selectedCues = ['cue4']
     const destination = '3.1'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
@@ -171,26 +171,26 @@ describe('moveCues', () => {
       { id: 'cue1' },
       { id: 'cue2' },
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
-          { id: 'cue5' },
+          { id: 'cue3.1' },
           { id: 'cue4' },
+          { id: 'cue3.2' },
         ],
       },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
+      { id: 'cue6' },
     ])
   })
 
   it('moves selected cue the end of group', async () => {
-    const selectedCues = ['cue5']
+    const selectedCues = ['cue4']
     const destination = '3.2'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
@@ -198,26 +198,26 @@ describe('moveCues', () => {
       { id: 'cue1' },
       { id: 'cue2' },
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
           { id: 'cue4' },
-          { id: 'cue5' },
         ],
       },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
+      { id: 'cue6' },
     ])
   })
 
   it('moves selected cue the end of group (using higher number)', async () => {
-    const selectedCues = ['cue5']
+    const selectedCues = ['cue4']
     const destination = '3.4'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
@@ -225,129 +225,129 @@ describe('moveCues', () => {
       { id: 'cue1' },
       { id: 'cue2' },
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
           { id: 'cue4' },
-          { id: 'cue5' },
         ],
       },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
+      { id: 'cue6' },
     ])
   })
 
   it('moves selected cues into the first position', async () => {
-    const selectedCues = ['cue5', 'cue8']
+    const selectedCues = ['cue4', 'cue6']
     const destination = '0'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
     expect(newCueOrder).to.deep.equal([
-      { id: 'cue5' },
-      { id: 'cue8' },
+      { id: 'cue4' },
+      { id: 'cue6' },
       { id: 'cue1' },
       { id: 'cue2' },
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
-          { id: 'cue4' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
         ],
       },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
     ])
   })
 
   it('moves selected cues to a middle position', async () => {
-    const selectedCues = ['cue1', 'cue2', 'cue8']
+    const selectedCues = ['cue1', 'cue2', 'cue6']
     const destination = '4'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
     expect(newCueOrder).to.deep.equal([
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
-          { id: 'cue4' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
         ],
       },
-      { id: 'cue5' },
+      { id: 'cue4' },
       { id: 'cue1' },
       { id: 'cue2' },
-      { id: 'cue8' },
+      { id: 'cue6' },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
     ])
   })
 
   it('moves selected cues into the last position', async () => {
-    const selectedCues = ['cue1', 'cue2', 'cue5']
+    const selectedCues = ['cue1', 'cue2', 'cue4']
     const destination = '6'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
     expect(newCueOrder).to.deep.equal([
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
-          { id: 'cue4' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
         ],
       },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
+      { id: 'cue6' },
       { id: 'cue1' },
       { id: 'cue2' },
-      { id: 'cue5' },
+      { id: 'cue4' },
     ])
   })
 
   it('moves selected cues into the last position (using higher number)', async () => {
-    const selectedCues = ['cue1', 'cue2', 'cue5']
+    const selectedCues = ['cue1', 'cue2', 'cue4']
     const destination = '50'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
     expect(newCueOrder).to.deep.equal([
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
-          { id: 'cue4' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
         ],
       },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
+      { id: 'cue6' },
       { id: 'cue1' },
       { id: 'cue2' },
-      { id: 'cue5' },
+      { id: 'cue4' },
     ])
   })
 
@@ -358,55 +358,55 @@ describe('moveCues', () => {
 
     expect(newCueOrder).to.deep.equal([
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
-          { id: 'cue4' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
         ],
       },
       { id: 'cue1' },
       { id: 'cue2' },
-      { id: 'cue5' },
+      { id: 'cue4' },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
+      { id: 'cue6' },
     ])
   })
 
   it('moves group to the beginning', async () => {
-    const selectedCues = ['group1']
+    const selectedCues = ['group3']
     const destination = '0'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
     expect(newCueOrder).to.deep.equal([
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
-          { id: 'cue4' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
         ],
       },
       { id: 'cue1' },
       { id: 'cue2' },
-      { id: 'cue5' },
+      { id: 'cue4' },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
+      { id: 'cue6' },
     ])
   })
 
   it('moves group to the middle', async () => {
-    const selectedCues = ['group2']
+    const selectedCues = ['group5']
     const destination = '2'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
@@ -414,80 +414,80 @@ describe('moveCues', () => {
       { id: 'cue1' },
       { id: 'cue2' },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
-          { id: 'cue4' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
         ],
       },
-      { id: 'cue5' },
-      { id: 'cue8' },
+      { id: 'cue4' },
+      { id: 'cue6' },
     ])
   })
 
   it('moves group to the end', async () => {
-    const selectedCues = ['group1']
+    const selectedCues = ['group3']
     const destination = '6'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
     expect(newCueOrder).to.deep.equal([
       { id: 'cue1' },
       { id: 'cue2' },
-      { id: 'cue5' },
+      { id: 'cue4' },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
+      { id: 'cue6' },
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
-          { id: 'cue4' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
         ],
       },
     ])
   })
 
   it('moves group after group', async () => {
-    const selectedCues = ['group1']
+    const selectedCues = ['group3']
     const destination = '5'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
     expect(newCueOrder).to.deep.equal([
       { id: 'cue1' },
       { id: 'cue2' },
-      { id: 'cue5' },
+      { id: 'cue4' },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
-          { id: 'cue4' },
+          { id: 'cue3.1' },
+          { id: 'cue3.2' },
         ],
       },
-      { id: 'cue8' },
+      { id: 'cue6' },
     ])
   })
 
   it('moves group inside group', async () => {
-    const selectedCues = ['group1']
+    const selectedCues = ['group3']
     const destination = '3.1'
     try {
       await moveCues(cueOrder, selectedCues, destination)
@@ -497,33 +497,33 @@ describe('moveCues', () => {
   })
 
   it('moves children to beginning', async () => {
-    const selectedCues = ['cue3', 'cue4']
+    const selectedCues = ['cue3.1', 'cue3.2']
     const destination = '0'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
     expect(newCueOrder).to.deep.equal([
-      { id: 'cue3' },
-      { id: 'cue4' },
+      { id: 'cue3.1' },
+      { id: 'cue3.2' },
       { id: 'cue1' },
       { id: 'cue2' },
       {
-        id: 'group1',
+        id: 'group3',
         children: [],
       },
-      { id: 'cue5' },
+      { id: 'cue4' },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
+      { id: 'cue6' },
     ])
   })
 
   it('moves children to middle', async () => {
-    const selectedCues = ['cue3', 'cue4']
+    const selectedCues = ['cue3.1', 'cue3.2']
     const destination = '4'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
@@ -531,25 +531,25 @@ describe('moveCues', () => {
       { id: 'cue1' },
       { id: 'cue2' },
       {
-        id: 'group1',
+        id: 'group3',
         children: [],
       },
-      { id: 'cue5' },
-      { id: 'cue3' },
       { id: 'cue4' },
+      { id: 'cue3.1' },
+      { id: 'cue3.2' },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
+      { id: 'cue6' },
     ])
   })
 
   it('moves children to end', async () => {
-    const selectedCues = ['cue3', 'cue4']
+    const selectedCues = ['cue3.1', 'cue3.2']
     const destination = '6'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
@@ -557,25 +557,25 @@ describe('moveCues', () => {
       { id: 'cue1' },
       { id: 'cue2' },
       {
-        id: 'group1',
+        id: 'group3',
         children: [],
       },
-      { id: 'cue5' },
+      { id: 'cue4' },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
-      { id: 'cue3' },
-      { id: 'cue4' },
+      { id: 'cue6' },
+      { id: 'cue3.1' },
+      { id: 'cue3.2' },
     ])
   })
 
   it('moves children to end (using higher number)', async () => {
-    const selectedCues = ['cue3', 'cue4']
+    const selectedCues = ['cue3.1', 'cue3.2']
     const destination = '6'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
@@ -583,47 +583,47 @@ describe('moveCues', () => {
       { id: 'cue1' },
       { id: 'cue2' },
       {
-        id: 'group1',
+        id: 'group3',
         children: [],
       },
-      { id: 'cue5' },
+      { id: 'cue4' },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
-      { id: 'cue8' },
-      { id: 'cue3' },
-      { id: 'cue4' },
+      { id: 'cue6' },
+      { id: 'cue3.1' },
+      { id: 'cue3.2' },
     ])
   })
 
   it('moves various types of selected cues to another position', async () => {
-    const selectedCues = ['cue2', 'group2', 'cue5', 'cue4']
+    const selectedCues = ['cue2', 'group5', 'cue4', 'cue3.2']
     const destination = '1'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
     expect(newCueOrder).to.deep.equal([
       { id: 'cue1' },
       { id: 'cue2' },
+      { id: 'cue3.2' },
       { id: 'cue4' },
-      { id: 'cue5' },
       {
-        id: 'group2',
+        id: 'group5',
         children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
+          { id: 'cue5.1' },
+          { id: 'cue5.2' },
         ],
       },
       {
-        id: 'group1',
+        id: 'group3',
         children: [
-          { id: 'cue3' },
+          { id: 'cue3.1' },
         ],
       },
-      { id: 'cue8' },
+      { id: 'cue6' },
     ])
   })
 })

--- a/tests/moveCues.test.js
+++ b/tests/moveCues.test.js
@@ -27,12 +27,13 @@ const cueOrder = [
 ]
 
 describe('moveCues', () => {
-  it('moves selected cue into a group position', async () => {
+  it('moves selected cue into the first position', async () => {
     const selectedCues = ['cue5']
-    const destination = '3.2'
+    const destination = '0'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
     expect(newCueOrder).to.deep.equal([
+      { id: 'cue5' },
       { id: 'cue1' },
       { id: 'cue2' },
       {
@@ -40,7 +41,6 @@ describe('moveCues', () => {
         children: [
           { id: 'cue3' },
           { id: 'cue4' },
-          { id: 'cue5' },
         ],
       },
       {
@@ -54,15 +54,15 @@ describe('moveCues', () => {
     ])
   })
 
-  it('moves selected cue into the first position', async () => {
+  it('moves selected cue into a middle position', async () => {
     const selectedCues = ['cue5']
-    const destination = '0'
+    const destination = '2'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
     expect(newCueOrder).to.deep.equal([
-      { id: 'cue5' },
       { id: 'cue1' },
       { id: 'cue2' },
+      { id: 'cue5' },
       {
         id: 'group1',
         children: [
@@ -108,9 +108,171 @@ describe('moveCues', () => {
     ])
   })
 
-  it('moves selected cues into the last position', async () => {
-    const selectedCues = ['cue1', 'cue2']
-    const destination = '6'
+  it('moves selected cue into the last position (using higher number)', async () => {
+    const selectedCues = ['cue5']
+    const destination = '100'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+        ],
+      },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+      { id: 'cue5' },
+    ])
+  })
+
+  it('moves selected cue to a begining of group', async () => {
+    const selectedCues = ['cue5']
+    const destination = '3.0'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue5' },
+          { id: 'cue3' },
+          { id: 'cue4' },
+        ],
+      },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+    ])
+  })
+
+  it('moves selected cue the middle of group', async () => {
+    const selectedCues = ['cue5']
+    const destination = '3.1'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue5' },
+          { id: 'cue4' },
+        ],
+      },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+    ])
+  })
+
+  it('moves selected cue the end of group', async () => {
+    const selectedCues = ['cue5']
+    const destination = '3.2'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+          { id: 'cue5' },
+        ],
+      },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+    ])
+  })
+
+  it('moves selected cue the end of group (using higher number)', async () => {
+    const selectedCues = ['cue5']
+    const destination = '3.4'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+          { id: 'cue5' },
+        ],
+      },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+    ])
+  })
+
+  it('moves selected cues into the first position', async () => {
+    const selectedCues = ['cue5', 'cue8']
+    const destination = '0'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue5' },
+      { id: 'cue8' },
+      { id: 'cue1' },
+      { id: 'cue2' },
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+        ],
+      },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+    ])
+  })
+
+  it('moves selected cues to a middle position', async () => {
+    const selectedCues = ['cue1', 'cue2', 'cue8']
+    const destination = '4'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
     expect(newCueOrder).to.deep.equal([
@@ -122,6 +284,32 @@ describe('moveCues', () => {
         ],
       },
       { id: 'cue5' },
+      { id: 'cue1' },
+      { id: 'cue2' },
+      { id: 'cue8' },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+    ])
+  })
+
+  it('moves selected cues into the last position', async () => {
+    const selectedCues = ['cue1', 'cue2', 'cue5']
+    const destination = '6'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+        ],
+      },
       {
         id: 'group2',
         children: [
@@ -132,6 +320,34 @@ describe('moveCues', () => {
       { id: 'cue8' },
       { id: 'cue1' },
       { id: 'cue2' },
+      { id: 'cue5' },
+    ])
+  })
+
+  it('moves selected cues into the last position (using higher number)', async () => {
+    const selectedCues = ['cue1', 'cue2', 'cue5']
+    const destination = '50'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+        ],
+      },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+      { id: 'cue1' },
+      { id: 'cue2' },
+      { id: 'cue5' },
     ])
   })
 
@@ -158,6 +374,60 @@ describe('moveCues', () => {
           { id: 'cue7' },
         ],
       },
+      { id: 'cue8' },
+    ])
+  })
+
+  it('moves group to the beginning', async () => {
+    const selectedCues = ['group1']
+    const destination = '0'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+        ],
+      },
+      { id: 'cue1' },
+      { id: 'cue2' },
+      { id: 'cue5' },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+    ])
+  })
+
+  it('moves group to the middle', async () => {
+    const selectedCues = ['group2']
+    const destination = '2'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+        ],
+      },
+      { id: 'cue5' },
       { id: 'cue8' },
     ])
   })
@@ -226,21 +496,21 @@ describe('moveCues', () => {
     }
   })
 
-  it('moves selected cue to a higher number', async () => {
-    const selectedCues = ['cue5']
-    const destination = '100'
+  it('moves children to beginning', async () => {
+    const selectedCues = ['cue3', 'cue4']
+    const destination = '0'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
 
     expect(newCueOrder).to.deep.equal([
+      { id: 'cue3' },
+      { id: 'cue4' },
       { id: 'cue1' },
       { id: 'cue2' },
       {
         id: 'group1',
-        children: [
-          { id: 'cue3' },
-          { id: 'cue4' },
-        ],
+        children: [],
       },
+      { id: 'cue5' },
       {
         id: 'group2',
         children: [
@@ -249,11 +519,88 @@ describe('moveCues', () => {
         ],
       },
       { id: 'cue8' },
-      { id: 'cue5' },
     ])
   })
 
-  it.only('moves many selected cue to another position', async () => {
+  it('moves children to middle', async () => {
+    const selectedCues = ['cue3', 'cue4']
+    const destination = '4'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      {
+        id: 'group1',
+        children: [],
+      },
+      { id: 'cue5' },
+      { id: 'cue3' },
+      { id: 'cue4' },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+    ])
+  })
+
+  it('moves children to end', async () => {
+    const selectedCues = ['cue3', 'cue4']
+    const destination = '6'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      {
+        id: 'group1',
+        children: [],
+      },
+      { id: 'cue5' },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+      { id: 'cue3' },
+      { id: 'cue4' },
+    ])
+  })
+
+  it('moves children to end (using higher number)', async () => {
+    const selectedCues = ['cue3', 'cue4']
+    const destination = '6'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      {
+        id: 'group1',
+        children: [],
+      },
+      { id: 'cue5' },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+      { id: 'cue3' },
+      { id: 'cue4' },
+    ])
+  })
+
+  it('moves various types of selected cues to another position', async () => {
     const selectedCues = ['cue2', 'group2', 'cue5', 'cue4']
     const destination = '1'
     const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
@@ -274,33 +621,6 @@ describe('moveCues', () => {
         id: 'group1',
         children: [
           { id: 'cue3' },
-        ],
-      },
-      { id: 'cue8' },
-    ])
-  })
-
-  it('moves selected cues to a begining of group', async () => {
-    const selectedCues = ['cue5']
-    const destination = '3.0'
-    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
-
-    expect(newCueOrder).to.deep.equal([
-      { id: 'cue1' },
-      { id: 'cue2' },
-      {
-        id: 'group1',
-        children: [
-          { id: 'cue5' },
-          { id: 'cue3' },
-          { id: 'cue4' },
-        ],
-      },
-      {
-        id: 'group2',
-        children: [
-          { id: 'cue6' },
-          { id: 'cue7' },
         ],
       },
       { id: 'cue8' },

--- a/tests/moveCues.test.js
+++ b/tests/moveCues.test.js
@@ -216,7 +216,7 @@ describe('moveCues', () => {
     ])
   })
 
-  it.only('moves group inside group', async () => {
+  it('moves group inside group', async () => {
     const selectedCues = ['group1']
     const destination = '3.1'
     try {
@@ -224,5 +224,86 @@ describe('moveCues', () => {
     } catch (error) {
       expect(error.message).to.equal('Cannot move a group header inside another group')
     }
+  })
+
+  it('moves selected cue to a higher number', async () => {
+    const selectedCues = ['cue5']
+    const destination = '100'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+          { id: 'cue4' },
+        ],
+      },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+      { id: 'cue5' },
+    ])
+  })
+
+  it.only('moves many selected cue to another position', async () => {
+    const selectedCues = ['cue2', 'group2', 'cue5', 'cue4']
+    const destination = '1'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      { id: 'cue4' },
+      { id: 'cue5' },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue3' },
+        ],
+      },
+      { id: 'cue8' },
+    ])
+  })
+
+  it('moves selected cues to a begining of group', async () => {
+    const selectedCues = ['cue5']
+    const destination = '3.0'
+    const newCueOrder = await moveCues(cueOrder, selectedCues, destination)
+
+    expect(newCueOrder).to.deep.equal([
+      { id: 'cue1' },
+      { id: 'cue2' },
+      {
+        id: 'group1',
+        children: [
+          { id: 'cue5' },
+          { id: 'cue3' },
+          { id: 'cue4' },
+        ],
+      },
+      {
+        id: 'group2',
+        children: [
+          { id: 'cue6' },
+          { id: 'cue7' },
+        ],
+      },
+      { id: 'cue8' },
+    ])
   })
 })


### PR DESCRIPTION
Introduced the `moveCues` function to handle cue reordering within a rundown, tests included.

> Dependency of [RSH-34: Batch operations for cues](https://www.notion.so/Batch-operations-for-cues-2c962d6dc44748c9887f3c883b9e6fe0?pvs=4).